### PR TITLE
Komarch 126 works api filters and tests

### DIFF
--- a/app/Http/Controllers/Admin/WorkCrudController.php
+++ b/app/Http/Controllers/Admin/WorkCrudController.php
@@ -50,4 +50,9 @@ class WorkCrudController extends CrudController
         $this->crud->denyAccess('create');
     }
 
+    protected function setupListOperation()
+    {
+        $this->crud->addButtonFromView('line', 'show_online', 'show_online', 'beginning');
+    }
+
 }

--- a/app/Http/Controllers/Api/WorkController.php
+++ b/app/Http/Controllers/Api/WorkController.php
@@ -14,6 +14,11 @@ class WorkController extends Controller
     {
         $works = $this->loadWorks($request);
 
+        // search
+        if ($request->filled('q')) {
+            $works->where('name', 'like', '%' .$request->input('q') . '%');
+        }
+
         // sort
         $works->orderBy(
             $request->input('sortby', 'created_at'),

--- a/app/Http/Controllers/Api/WorkController.php
+++ b/app/Http/Controllers/Api/WorkController.php
@@ -52,6 +52,14 @@ class WorkController extends Controller
             $works->withAnyTags($request->input('tags', []));
         }
 
+        if ($request->has('year_from')) {
+            $works->where('date_construction_start', '>=', $request->input('year_from'));
+        }
+
+        if ($request->has('year_until')) {
+            $works->where('date_construction_ending', '<=', $request->input('year_until'));
+        }
+
         return $works;
     }
 }

--- a/app/Http/Resources/MediaResource.php
+++ b/app/Http/Resources/MediaResource.php
@@ -19,6 +19,7 @@ class MediaResource extends JsonResource
             'size' => $this->size,
             'mime_type' => $this->mime_type,
             'url' => $this->getFullUrl(),
+            'srcset' => $this->getSrcset(),
         ];
     }
 }

--- a/tests/Feature/DocumentApiTest.php
+++ b/tests/Feature/DocumentApiTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class DocumentApiTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    public function testIndex()
+    {
+        $response = $this->get('/api/documents');
+        $response->assertStatus(200);
+    }
+
+    public function testFilters()
+    {
+        $response = $this->get('/api/documents-filters');
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/WorkApiTest.php
+++ b/tests/Feature/WorkApiTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class WorkApiTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    public function testIndex()
+    {
+        $response = $this->get('/api/works');
+        $response->assertStatus(200);
+    }
+
+    public function testFilters()
+    {
+        $response = $this->get('/api/works-filters');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
(see commit messages)
added to works api query parameters `q`, `year_from`, `year_until`
+ include `srcset` in api response for media
+ button show online in works admin
![Screenshot 2021-06-15 at 18 04 10](https://user-images.githubusercontent.com/2682941/122086684-3cca1600-ce04-11eb-983f-d4864f088cca.png)
