### PR TITLE
Media import for Contest and ContestResult

### DIFF
--- a/app/Jobs/ImportFromUrad.php
+++ b/app/Jobs/ImportFromUrad.php
@@ -3,6 +3,7 @@
 namespace App\Jobs;
 
 use App\Models\Contest;
+use App\Models\ContestResult;
 use App\Models\Work;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -92,6 +93,10 @@ class ImportFromUrad implements ShouldQueue
         foreach (Contest::cursor() as $contest) {
             $this->importModelMedia('App\Models\Contest', $contest, ['contest_pictures', 'contest_attachments']);
             $this->importModelTags('App\Models\Contest', $contest);
+        }
+
+        foreach (ContestResult::cursor() as $contestResult) {
+            $this->importModelMedia('App\Models\Contestresult', $contestResult, ['contestresult_pictures']);
         }
     }
 

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -3,9 +3,21 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\Tags\HasTags;
 
-class Contest extends Model
+class Contest extends Model implements HasMedia
 {
-    use HasTags;
+    use HasTags, InteractsWithMedia;
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection('contest_pictures')
+            ->withResponsiveImages();
+
+        $this
+            ->addMediaCollection('contest_attachments');
+    }
 }

--- a/app/Models/ContestResult.php
+++ b/app/Models/ContestResult.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class ContestResult extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+
+    protected $table = 'contestresults';
+
+    public function registerMediaCollections(): void
+    {
+        $this
+            ->addMediaCollection('contestresult_pictures')
+            ->withResponsiveImages();
+    }
+}

--- a/app/Models/Work.php
+++ b/app/Models/Work.php
@@ -50,7 +50,7 @@ class Work extends Model implements HasMedia
     public function registerMediaCollections(): void
     {
         $this
-            ->addMediaCollection('images')
+            ->addMediaCollection('work_pictures')
             ->withResponsiveImages();
     }
 


### PR DESCRIPTION
Note this re-names the Work collection from `images` to `work_pictures`. If you have Work media already imported, either delete them or rename the collection in the DB.