### PR TITLE
add ResolveRedirectNotFound listener and redirect for found page slug

### DIFF
--- a/app/Listeners/ResolveRedirectNotFound.php
+++ b/app/Listeners/ResolveRedirectNotFound.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Models\Page;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Spatie\MissingPageRedirector\Events\RedirectNotFound;
+
+class ResolveRedirectNotFound
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  RedirectNotFound  $event
+     * @return void
+     */
+    public function handle(RedirectNotFound $event)
+    {
+        $slug = last($event->request->segments());
+        $page = Page::where('wp_post_name', $slug)->first();
+        if ($page) {
+            return abort(redirect($page->url)); // because it doesn't work without abort
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,10 +2,12 @@
 
 namespace App\Providers;
 
+use App\Listeners\ResolveRedirectNotFound;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Auth\Listeners\SendEmailVerificationNotification;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\Event;
+use Spatie\MissingPageRedirector\Events\RedirectNotFound;
 
 class EventServiceProvider extends ServiceProvider
 {
@@ -17,6 +19,9 @@ class EventServiceProvider extends ServiceProvider
     protected $listen = [
         Registered::class => [
             SendEmailVerificationNotification::class,
+        ],
+        RedirectNotFound::class => [
+            ResolveRedirectNotFound::class,
         ],
     ];
 


### PR DESCRIPTION
table `redirects` doesn't contain records for pages
I decided to use `RedirectNotFound` event -> https://github.com/spatie/laravel-missing-page-redirector/commit/c83cc87581b0b3b51e45c3559e4faabe0f818a0c
but not 100% sure, if listener is the right place for handling this 