### PR TITLE
Komarch 260 gallery adaptive thumbnails

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "postcss": "^7.0.35",
         "qs": "^6.10.1",
         "resolve-url-loader": "^3.1.0",
-        "swiper": "^5.2.1",
+        "swiper": "^5.4.5",
         "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.4",
         "v-click-outside": "^3.1.2",
         "vue": "^2.6.12",

--- a/resources/js/components/ImageGallery.vue
+++ b/resources/js/components/ImageGallery.vue
@@ -26,7 +26,7 @@
           :height="image.height"
           ref="img"
           :alt="image.alt"
-          class="w-full h-24 object-cover cursor-pointer"
+          class="w-auto h-24 cursor-pointer"
           @click="onThumbnailClicked(index)"
           onload="window.requestAnimationFrame(function(){if(!(size=getBoundingClientRect().width))return;onload=null;sizes=Math.ceil(size/window.innerWidth*100)+'vw';});"
         >
@@ -59,20 +59,8 @@ export default {
       images: [],
       selectedIndex: 0,
       swiperOptions: {
-        slidesPerView: 2,
-        spaceBetween: 20,
-        breakpoints: {
-          // when window width is >= 640px
-          640: {
-            slidesPerView: 3,
-            spaceBetween: 20
-          },
-          // when window width is >= 1024px
-          1024: {
-            slidesPerView: 4,
-            spaceBetween: 20
-          }
-        }
+        slidesPerView: 'auto',
+        spaceBetween: 20
       }
     }
   },
@@ -84,7 +72,6 @@ export default {
   async created () {
     const { data } = await this.axiosGet(this.sourceUrl)
     this.images = data
-    console.log(this.imgs)
   },
   methods: {
     onThumbnailClicked (index) {
@@ -103,5 +90,8 @@ export default {
 <style>
 .toolbar-btn__rotate, .toolbar-btn__resize {
   display: none;
+}
+.swiper-container .swiper-slide {
+  width: auto;
 }
 </style>


### PR DESCRIPTION
adjust image gallery component to show thumbnails with adaptive `width` + keep proportions


before:
<img width="966" alt="Snímka obrazovky 2022-10-11 o 23 47 53" src="https://user-images.githubusercontent.com/2682941/195204556-7ffa0af0-c273-41cf-8e11-b57271452723.png">


after:
<img width="943" alt="Snímka obrazovky 2022-10-11 o 23 48 03" src="https://user-images.githubusercontent.com/2682941/195204566-c03447e4-ad7b-453e-a629-e995617b4530.png">


